### PR TITLE
Update and rename chain844.sh to sectoranti8444.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# chaingreen-anti8444
-Remove 8444 connections from Chaingreen node on Linux
+# sector-anti8444
+Remove 8444 connections from sector node on Linux
 
-This was due to cgn and chia having the same ssl cert so connections came through from wrong fork essentially.  This happens with other forks put out by devs that don't know what they're doing yet and do not understand what they actually need to change in their code for their own fork to avoid stuff like this.   It's a learning process for them and this was one of the quirks due to using the orig certs.
+This was due to sector and chia having the same ssl cert so connections came through from wrong fork essentially.  This happens with other forks put out by devs that don't know what they're doing yet and do not understand what they actually need to change in their code for their own fork to avoid stuff like this.   It's a learning process for them and this was one of the quirks due to using the orig certs.
 
 Anyone claiming this was due to bot attacks is an absolute idiot that has no clue what they are talking about, nor a clue about how any of the forks actually work, and should be ignored.  
 
 Just ignore Fubar as he's nuts and not very bright. He's been told all this but chooses to spout tinfoil hat conspiracy theories.  
 
-
+bithadder : I'm going credit fubar for adding the 120s sleep to the end of the script XD
 

--- a/chain844.sh
+++ b/chain844.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-echo Keeping free of Chia nodes...
-while true; do
-for i in `/usr/lib/chaingreen-blockchain/resources/app.asar.unpacked/daemon/chaingreen show -c | grep 8444 | awk '{ print $4 }' | sed 's/\.\.\.//'`; do /usr/lib/chaingreen-blockchain/resources/app.asar.unpacked/daemon/chaingreen show
- -r $i;done
-done

--- a/sectoranti8444.sh
+++ b/sectoranti8444.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo Keeping free of Chia nodes...
+while true; do
+for i in `~/sector-blockchain/venv/bin/sector show -c | grep 8444 | awk '{ print $4 }' | sed 's/\.\.\.//'`; do ~/sector-blockchain/venv/bin/sector show -r $i;done
+sleep 120
+done


### PR DESCRIPTION
for those who installed using git clone repository of the sector blockchain
this script will remove the 8444 nodes connecting due to sector still using chia's ssl certificates.
added 120s sleep so (assuming) that the process won't burden the rpc somewhat (idk what I'm doing really)